### PR TITLE
Add version check for method parameter

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -90,7 +90,11 @@ class Spellchecker : public Nan::ObjectWrap {
 
     std::vector<uint16_t> text(string->Length() + 1);
 
-    string->Write(info.GetIsolate(), reinterpret_cast<uint16_t *>(text.data()));
+    string->Write(
+#if V8_MAJOR_VERSION > 6
+      info.GetIsolate(),
+#endif
+      reinterpret_cast<uint16_t *>(text.data()));
 
     Spellchecker* that = Nan::ObjectWrap::Unwrap<Spellchecker>(info.Holder());
     std::vector<MisspelledRange> misspelled_ranges = that->impl->CheckSpelling(text.data(), text.size());


### PR DESCRIPTION
The parameter is outdated and prohibits compilation with new Electron/V8. I have added macros the same way as the original node-spellchecker does https://github.com/atom/node-spellchecker/blob/master/src/main.cc