### PR TITLE
Use N-Api to improve ABI stability of native addon

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,11 +26,27 @@
   'targets': [
     {
       'target_name': 'spellchecker',
-      'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
+      'include_dirs': ["<!@(node -p \"require('node-addon-api').include\")"],
       'sources': [
         'src/main.cc',
       ],
+      'cflags!': [ '-fno-exceptions' ],
+      'cflags_cc!': [ '-fno-exceptions' ],
+      'xcode_settings': {
+        'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+        'CLANG_CXX_LIBRARY': 'libc++',
+        'MACOSX_DEPLOYMENT_TARGET': '10.7',
+      },
+      'msvs_settings': {
+        'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+      },
       'conditions': [
+        ['OS=="mac"', {
+          'cflags+': ['-fvisibility=hidden'],
+          'xcode_settings': {
+            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
+          }
+        }],
         ['spellchecker_use_hunspell=="true"', {
           'dependencies': [
             'hunspell',

--- a/package-lock.json
+++ b/package-lock.json
@@ -265,10 +265,10 @@
       "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
       "dev": true
     },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    "node-addon-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "jasmine-focused": "1.x"
   },
   "dependencies": {
-    "nan": "^2.14.0"
+    "node-addon-api": "*"
   }
 }


### PR DESCRIPTION
This PR switches the project from leveraging Native Abstractions for Node.js to N-API using Node-Addon-Api for C++. This is to solve the recurring issues that NAN projects run into with ABI stability. In particular, when loading this library in Electron 7.1.2 we are receiving the error: (node:26305) Electron: Loading non context-aware native modules in the renderer process is deprecated and will stop working at some point in the future, please see https://github.com/electron/electron/issues/18397 for more information.

When installing Node-Addon-Api, I enabled exceptions in C++ and the exception handling for Node-Addon-Api so that writing the extension doesn't require checking error codes after every operation.

No changes have been made to the external API.